### PR TITLE
#8 | Replace time.Sleep with time.Ticker in deleteOutdated

### DIFF
--- a/internal/initializer/cleanup.go
+++ b/internal/initializer/cleanup.go
@@ -34,18 +34,19 @@ func Cleanup(ctx context.Context) {
 }
 
 func deleteOutdated(ctx context.Context) error {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("context is done: %w", ctx.Err())
-		default:
+		case <-t.C:
 			log.Println("delete outdated cycle")
 
 			if err := message.DeleteOutdated(ctx); err != nil {
 				return fmt.Errorf("error while executing message.DeleteOutdated: %w", err)
 			}
-
-			time.Sleep(interval)
 		}
 	}
 }


### PR DESCRIPTION
# What was changed

I've replaced the cycle execution method in `deleteOutdated` function

# Background

It was changed because of better use of designated function.

# How it can be tested

CI + manually

# Keep in mind that...

n/a
